### PR TITLE
feat:   replace wget with requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ When I want to change my Hostuser avatar on Github, my Github won't open, so loo
 
 ## Install
 
-This project uses [python3](https://python.org) and [wget](https://www.gnu.org/software/wget/). Make sure you have them installed locally.
+This project uses [python3](https://python.org), [python3](https://python.org) using modules are [os](https://docs.python.org/3/library/os.html) and [requests](https://requests.readthedocs.io/). Make sure you have them installed locally.
  
 ```sh
 git clone https://github.com/ZhangDongzai/GithubHostUpdate.git

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 
 ## 安装
 
-这个项目使用了[python3](https://python.org)和[wget](https://www.gnu.org/software/wget/)。请确保你本地安装了它们。
+这个项目使用了[python3](https://python.org), [python3](https://python.org)使用的模块有[os](https://docs.python.org/3/library/os.html)和[requests](https://requests.readthedocs.io/)。请确保你本地安装了它们。
  
 ```sh
 git clone https://github.com/ZhangDongzai/GithubHostUpdate.git

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 # GithubHostsUpdate
 
 from os import name, system
+from requests import get, Response
 
 
 file = {1: ["https://hosts.gitcdn.top/hosts.txt",
@@ -14,7 +15,6 @@ file = {1: ["https://hosts.gitcdn.top/hosts.txt",
 
 file_number = 2
 file_encoding = "utf-8"
-
 
 def UpdateFile(file_number: int=file_number):
     global file_url, file_begin, file_end, file_name, file_location
@@ -32,15 +32,19 @@ def UpdateFile(file_number: int=file_number):
         file_location = "/etc/hosts"
 
 
-def download() -> None:
-    """download the file"""  
-    system("wget "+file_url)
+def download() -> Response:
+    """download the file"""
+    global download_file_content
+
+    # 下载数据
+    # 代码解析:
+    # requests.get(file_url) -> requests.Response
+    # requests.Response.content -> bytes
+    # str(bytes, encoding="utf-8") -> str
+    # str.split('\n') -> list
+    download_file_content = str(get(file_url).content, encoding="utf-8").split('\n')
 
 def writeToHostsFile() -> None:
-    # read the file and copy its content
-    with open(file=file_name, mode="r", encoding=file_encoding) as file:
-        download_file_content = file.readlines()
-
     # read hosts file
     with open(file=file_location, mode="r", encoding=file_encoding) as file:
         hosts_file_content = file.readlines()
@@ -62,19 +66,9 @@ def writeToHostsFile() -> None:
             # the file wrote hosts before
             file.writelines(hosts_file_content[0: begin-1] + download_file_content + hosts_file_content[end+1: -1])
 
-def deleteFile() -> None:
-    """delete the download file"""
-    if name == "nt":
-        # Windows
-        system("del "+file_name)
-    elif name == "posix":
-        # Linux or MacOS
-        system("rm "+file_name)
-
 
 if __name__ == "__main__":
     UpdateFile()
     download()
     writeToHostsFile()
-    deleteFile()
     


### PR DESCRIPTION
# New Version is Coming
We replace [wget](https://www.gnu.org/software/wget/) with [requests](https://requests.readthedocs.io/).It helps users save time on installing [wget](https://www.gnu.org/software/wget/) and the program won't make files.